### PR TITLE
Fallback in case of key presence with nil value.

### DIFF
--- a/lib/chef/provisioning/transport/ssh.rb
+++ b/lib/chef/provisioning/transport/ssh.rb
@@ -42,7 +42,7 @@ module Provisioning
         @ssh_options = init_ssh_options.clone
         @options = options
         @config = global_config
-        @remote_forwards = ssh_options.delete(:remote_forwards) { Array.new }
+        @remote_forwards = ssh_options.delete(:remote_forwards) || Array.new
         @never_forward_localhost = ssh_options.delete(:never_forward_localhost)
       end
 


### PR DESCRIPTION
The `:remote_forwards` key can be present but be nil which leads to a `undefined method `each' for nil:NilClass` when the `@remote_forwards.each` is encountered.

Be more defensive by falling back to an array in the case of a falsy (eg nil) value.